### PR TITLE
Stop adding additional newline when reading from stdin

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -73,13 +73,13 @@ export function processStream(fileName: string, input: NodeJS.ReadableStream, op
     var promise = new Promise<string>((resolve, reject) => {
         var fragment = "";
         input.on("data", (chunk: string) => {
-            if (chunk === "") {
-                return;
-            }
             fragment += chunk;
         });
 
         input.on("end", () => {
+            if (fragment.slice(-1) === "\n") {
+                fragment = fragment.slice(0,-1)
+            }
             resolve(fragment);
         });
     });

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -78,7 +78,7 @@ export function processStream(fileName: string, input: NodeJS.ReadableStream, op
 
         input.on("end", () => {
             if (fragment.slice(-1) === "\n") {
-                fragment = fragment.slice(0,-1)
+                fragment = fragment.slice(0, -1);
             }
             resolve(fragment);
         });


### PR DESCRIPTION
When reading from stdin, an extra newline character was always being appended to the input. This fixes that.