### PR TITLE
Add 'next' support for TypeScript 2.0.0-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "glob-expand": "^0.1.0"
   },
   "peerDependencies": {
-    "typescript": "^1.0.0 || >=1.8.0-dev || >=1.9.0-dev"
+    "typescript": "^1.0.0 || >=1.8.0-dev || >=1.9.0-dev || >=2.0.0-dev"
   },
   "devDependencies": {
     "dtsm": "^1.1.0",


### PR DESCRIPTION
Following https://github.com/Microsoft/TypeScript/pull/9377, the `nightly` version of TypeScript is now (at the time of writing):

```
$ tsc --version
Version 2.0.0-dev.20160630
```