### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ now `indentSize` parameter is ignored. it is TypeScript compiler matters.
 
 ## Read Settings From Files
 
-1st. Read settings from tsfmt.json.
+1st. Read settings from tsfmt.json. Bellow are the example with [default values](https://github.com/vvakame/typescript-formatter/blob/master/lib/utils.ts#L11-L27):
 
 ```json
 {


### PR DESCRIPTION
Mentioned that the example shows default values (and added link to the code)