### PR TITLE
support "include" and "exclude" simultaneously with "files"

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -51,7 +51,9 @@ export function readFilesFromTsconfig(configPath: string): string[] {
 
     let tsconfigDir = path.dirname(configPath);
     let tsconfig: TsConfigJSON = parseJSON(fs.readFileSync(configPath, "utf-8"));
-    if (tsconfig.files) {
+    if (tsconfig.files && (tsconfig.include || tsconfig.exclude)) {
+        return tsconfig.files.concat(tsMatchFiles(tsconfig.exclude || [], tsconfig.include || []));
+    } else if (tsconfig.files) {
         let files: string[] = tsconfig.files;
         return files.map(filePath => path.resolve(tsconfigDir, filePath));
     } else if (tsconfig.filesGlob) {


### PR DESCRIPTION
Version 2 of TypeScript supports now glob-like file patterns ("include" and "exclude" properties) that are combined with "files" property:

[Glob support in tsconfig.json](https://github.com/Microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#glob-support-in-tsconfigjson):

> If the "files" or "include" properties are specified, the compiler will instead include the union of the files included by those two properties. Files in the directory specified using the "outDir" compiler option are always excluded unless explicitly included via the "files" property (even when the "exclude" property is specified).