### PR TITLE
final newline character via .editorconfig

### DIFF
--- a/lib/provider/editorconfig.ts
+++ b/lib/provider/editorconfig.ts
@@ -43,3 +43,21 @@ export default function makeFormatCodeOptions(fileName: string, opts: Options, f
             return formatOptions;
         });
 }
+
+
+export function postProcess(fileName: string, formattedCode: string, opts: Options, formatOptions: ts.FormatCodeOptions): Promise<string> {
+
+    if (opts.verbose && opts.baseDir && !emitBaseDirWarning) {
+        console.log("editorconfig is not supported baseDir options");
+        emitBaseDirWarning = true;
+    }
+
+    return editorconfig
+        .parse(fileName)
+        .then(config => {
+            if (config.insert_final_newline) {
+                return formattedCode.replace(/\s+$/, formatOptions.NewLineCharacter);
+            }
+            return formattedCode;
+        });
+}

--- a/test/expected/tsfmt/b/main.ts
+++ b/test/expected/tsfmt/b/main.ts
@@ -378,5 +378,5 @@ class Vector/* /*
  */	return rayTracer.render( defaultScene(),ctx,256,256 );/* 
  */}/* 
  *//* 
- */exec();/* /* 
- */ */
+ */exec();/* 
+ */

--- a/test/indexSpec.ts
+++ b/test/indexSpec.ts
@@ -196,7 +196,7 @@ describe("tsfmt test", () => {
                 .then(result => {
                     assert(result !== null);
                     assert(result.error === false);
-                    assert(result.dest === "class Sample { getString(): string { return \"hi!\"; } }\r\n");
+                    assert(result.dest === "class Sample { getString(): string { return \"hi!\"; } }");
                 });
         });
     });


### PR DESCRIPTION
This PR tries to address #63 by moving the *insert final newline character* logic to an `editorconfig` post process function. The post processor will insert a final newline only if the `insert_final_newline` is set to true. 