### PR TITLE
Add TypeScript 2.2.0-dev peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "glob-expand": "^0.2.1"
   },
   "peerDependencies": {
-    "typescript": "^2.0.6 || >=2.1.0-dev"
+    "typescript": "^2.0.6 || >=2.1.0-dev || >=2.2.0-dev"
   },
   "devDependencies": {
     "@types/glob-expand": "^0.0.30",


### PR DESCRIPTION
```bash
cd `mktemp -d`
npm init --force
npm install --save-dev typescript@next typescript-formatter
```

gives the output:

```
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
tmp.FZNFd9q2JX@1.0.0 /tmp/tmp.FZNFd9q2JX
├── UNMET PEER DEPENDENCY typescript@2.2.0-dev.20161115

....
```

Doesn't appear to be a way to do this in a more elegant/future-proof way:

https://docs.npmjs.com/misc/semver#prerelease-tags