### PR TITLE
Use latest release of TypeScript 2.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "mocha": "^3.0.2",
     "power-assert": "^1.4.2",
     "tslint": "^3.15.1",
-    "typescript": "^2.0.10"
+    "typescript": "^2.1.5"
   }
 }


### PR DESCRIPTION
Hi, 

TypeScript 2.1 has been released for sometime. It's time to remove the require of `-dev` peerDependencies