### PR TITLE
Fix an issue with applying edits

### DIFF
--- a/lib/formatter.ts
+++ b/lib/formatter.ts
@@ -27,6 +27,15 @@ export default function format(fileName: string, text: string, options = createD
     function applyEdits(text: string, edits: ts.TextChange[]): string {
         // Apply edits in reverse on the existing text
         let result = text;
+
+        // An issue with `ts.formatting.formatDocument` is that it does
+        // not always give the edits array in ascending order of change start
+        // point. This can result that we add or remove some character in
+        // the begining of the document, making the all the other edits
+        // offsets invalid. 
+
+        // We resolve this by sorting edits by ascending start point
+        edits.sort((a, b) => a.span.start - b.span.start);
         for (let i = edits.length - 1; i >= 0; i--) {
             let change = edits[i];
             let head = result.slice(0, change.span.start);

--- a/test/expected/schemats/main.json
+++ b/test/expected/schemats/main.json
@@ -1,0 +1,17 @@
+{
+  "indentSize": 4,
+  "tabSize": 4,
+  "indentStyle": 2,
+  "newLineCharacter": "\r\n",
+  "convertTabsToSpaces": true,
+  "insertSpaceAfterCommaDelimiter": true,
+  "insertSpaceAfterSemicolonInForStatements": true,
+  "insertSpaceBeforeAndAfterBinaryOperators": true,
+  "insertSpaceAfterKeywordsInControlFlowStatements": true,
+  "insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
+  "insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": false,
+  "insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets": false,
+  "insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces": false,
+  "placeOpenBraceOnNewLineForFunctions": false,
+  "placeOpenBraceOnNewLineForControlBlocks": false
+}

--- a/test/expected/schemats/main.ts
+++ b/test/expected/schemats/main.ts
@@ -1,0 +1,19 @@
+/**
+ * AUTO-GENERATED FILE @ 2016-12-07 13:17:46 - DO NOT EDIT!
+ *
+ * This file was generated with schemats node package:
+ * $ schemats generate -c postgres://username:password@localhost/test -t users -o ./test/osm.ts
+ *
+ * Re-run the command above.
+ */
+
+
+export namespace cta_situationcompte_scoFields {
+    export type sco_id = number;
+    export type sco_total_debit = number;
+    export type sco_total_credit = number;
+    export type sco_nb_ecritures = number;
+    export type pst_id = number;
+    export type cpt_id = number;
+
+}

--- a/test/fixture/schemats/main.ts
+++ b/test/fixture/schemats/main.ts
@@ -1,0 +1,19 @@
+            /**
+             * AUTO-GENERATED FILE @ 2016-12-07 13:17:46 - DO NOT EDIT!
+             *
+             * This file was generated with schemats node package:
+             * $ schemats generate -c postgres://username:password@localhost/test -t users -o ./test/osm.ts
+             *
+             * Re-run the command above.
+             */
+
+    
+        export namespace cta_situationcompte_scoFields {
+        export type sco_id = number;
+export type sco_total_debit = number;
+export type sco_total_credit = number;
+export type sco_nb_ecritures = number;
+export type pst_id = number;
+export type cpt_id = number;
+
+        }


### PR DESCRIPTION
In this pull request we address the issue raised in https://github.com/vvakame/typescript-formatter/issues/74 and https://github.com/SweetIQ/schemats/issues/37

Basically, in `formatter.ts` `applyEdits` function, we apply the edits from the end of the file towards the beginning, under the assumption that `ts.formatting.formatDocument` always returns an `edits` array sorted in ascending order of the change start point. In practice, this assumption is not always held true. This is the cause for the bugs mentioned above.

To resolve this, we simply sort the edits array in ascending order of its change start point. 