### PR TITLE
add failing test for check-typecast

### DIFF
--- a/test/expected/tslint/whitespace-check-typecast/main.json
+++ b/test/expected/tslint/whitespace-check-typecast/main.json
@@ -1,0 +1,17 @@
+{
+  "indentSize": 4,
+  "tabSize": 4,
+  "indentStyle": 2,
+  "newLineCharacter": "\r\n",
+  "convertTabsToSpaces": true,
+  "insertSpaceAfterCommaDelimiter": false,
+  "insertSpaceAfterSemicolonInForStatements": false,
+  "insertSpaceBeforeAndAfterBinaryOperators": false,
+  "insertSpaceAfterKeywordsInControlFlowStatements": false,
+  "insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
+  "insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": false,
+  "insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets": false,
+  "insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces": false,
+  "placeOpenBraceOnNewLineForFunctions": false,
+  "placeOpenBraceOnNewLineForControlBlocks": false
+}

--- a/test/expected/tslint/whitespace-check-typecast/main.ts
+++ b/test/expected/tslint/whitespace-check-typecast/main.ts
@@ -1,0 +1,1 @@
+const a=<any> 5

--- a/test/fixture/tslint/whitespace-check-typecast/main.ts
+++ b/test/fixture/tslint/whitespace-check-typecast/main.ts
@@ -1,0 +1,1 @@
+const a=<any>5

--- a/test/fixture/tslint/whitespace-check-typecast/tsfmt.json
+++ b/test/fixture/tslint/whitespace-check-typecast/tsfmt.json
@@ -1,0 +1,10 @@
+{
+    "insertSpaceAfterCommaDelimiter": false,
+    "insertSpaceAfterSemicolonInForStatements": false,
+    "insertSpaceBeforeAndAfterBinaryOperators": false,
+    "insertSpaceAfterKeywordsInControlFlowStatements": false,
+    "insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
+    "insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": false,
+    "placeOpenBraceOnNewLineForFunctions": false,
+    "placeOpenBraceOnNewLineForControlBlocks": false
+}

--- a/test/fixture/tslint/whitespace-check-typecast/tslint.json
+++ b/test/fixture/tslint/whitespace-check-typecast/tslint.json
@@ -1,0 +1,7 @@
+{
+    "rules": {
+        "whitespace": [true,
+            "check-typecast"
+        ]
+    }
+}


### PR DESCRIPTION
The formatter add no space after a typecast at the moment, it actually removes it, which is at odds with the tslint:recommended rules.

With some help I can probably fix this my self, I know that something like this needs to be added [here](https://github.com/vvakame/typescript-formatter/blob/master/lib/provider/tslintjson.ts#L74)

```js
            } else if (value === "check-typecast") {
              formatSettings.insertSpaceAfterTypeCast = true;
            }
```

But where does the actual formatting happen?