### PR TITLE
feat: add missing rules recently added by vscode

### DIFF
--- a/lib/provider/vscodesettings.ts
+++ b/lib/provider/vscodesettings.ts
@@ -15,8 +15,10 @@ interface VSCodeSettings {
     "typescript.format.insertSpaceAfterFunctionKeywordForAnonymousFunctions": boolean;
     "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": boolean;
     "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets": boolean;
+    "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": boolean;
     "typescript.format.insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces": boolean;
     "typescript.format.insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces": boolean;
+    "typescript.format.insertSpaceBeforeFunctionParenthesis": boolean;
     "typescript.format.placeOpenBraceOnNewLineForFunctions": boolean;
     "typescript.format.placeOpenBraceOnNewLineForControlBlocks": boolean;
 
@@ -58,11 +60,17 @@ export default function makeFormatCodeOptions(fileName: string, opts: Options, f
     if (config["typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets"] != null) {
         formatSettings.insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets = config["typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets"];
     }
+    if (config["typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces"] != null) {
+        formatSettings.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces = config["typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces"];
+    }
     if (config["typescript.format.insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces"] != null) {
         formatSettings.insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces = config["typescript.format.insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces"];
     }
     if (config["typescript.format.insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces"] != null) {
         formatSettings.insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces = config["typescript.format.insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces"];
+    }
+    if (config["typescript.format.insertSpaceBeforeFunctionParenthesis"] != null) {
+        formatSettings.insertSpaceBeforeFunctionParenthesis = config["typescript.format.insertSpaceBeforeFunctionParenthesis"];
     }
     if (config["typescript.format.placeOpenBraceOnNewLineForFunctions"] != null) {
         formatSettings.placeOpenBraceOnNewLineForFunctions = config["typescript.format.placeOpenBraceOnNewLineForFunctions"];

--- a/test/expected/vscode/a/main.json
+++ b/test/expected/vscode/a/main.json
@@ -17,7 +17,7 @@
   "insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces": true,
   "insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces": true,
   "insertSpaceAfterTypeAssertion": false,
-  "insertSpaceBeforeFunctionParenthesis": false,
+  "insertSpaceBeforeFunctionParenthesis": true,
   "placeOpenBraceOnNewLineForFunctions": true,
   "placeOpenBraceOnNewLineForControlBlocks": true
 }

--- a/test/expected/vscode/a/main.ts
+++ b/test/expected/vscode/a/main.ts
@@ -1,6 +1,6 @@
 class Sample
 {
-    hello( word: string = "world" ): string { return "Hello, " + word; }
+    hello ( word: string = "world" ): string { return "Hello, " + word; }
 }
 
 var s: Sample = new Sample();

--- a/test/expected/vscode/b/main.json
+++ b/test/expected/vscode/b/main.json
@@ -13,7 +13,7 @@
   "insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
   "insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": false,
   "insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets": false,
-  "insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": true,
+  "insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false,
   "insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces": false,
   "insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces": false,
   "insertSpaceAfterTypeAssertion": false,

--- a/test/expected/vscode/b/main.ts
+++ b/test/expected/vscode/b/main.ts
@@ -1,6 +1,6 @@
 class Sample {
-    hello(word: string="world"): string { return "Hello, "+word; }
+    hello(word: string="world"): string {return "Hello, "+word;}
 }
 
 var s: Sample=new Sample();
-if(s===s) { console.log(s.hello()); }
+if(s===s) {console.log(s.hello());}

--- a/test/fixture/vscode/a/.vscode/settings.json
+++ b/test/fixture/vscode/a/.vscode/settings.json
@@ -8,8 +8,10 @@
     "typescript.format.insertSpaceAfterFunctionKeywordForAnonymousFunctions": true,
     "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": true,
     "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets": true,
+    "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": true,
     "typescript.format.insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces": true,
     "typescript.format.insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces": true,
+    "typescript.format.insertSpaceBeforeFunctionParenthesis": true,
     "typescript.format.placeOpenBraceOnNewLineForFunctions": true,
     "typescript.format.placeOpenBraceOnNewLineForControlBlocks": true
 }

--- a/test/fixture/vscode/b/.vscode/settings.json
+++ b/test/fixture/vscode/b/.vscode/settings.json
@@ -8,8 +8,10 @@
     "typescript.format.insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
     "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": false,
     "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets": false,
+    "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false,
     "typescript.format.insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces": false,
     "typescript.format.insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces": false,
+    "typescript.format.insertSpaceBeforeFunctionParenthesis": false,
     "typescript.format.placeOpenBraceOnNewLineForFunctions": false,
     "typescript.format.placeOpenBraceOnNewLineForControlBlocks": false
 }


### PR DESCRIPTION
VSCode now supports the following two rules:
insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces
insertSpaceBeforeFunctionParenthesis

https://code.visualstudio.com/docs/getstarted/settings