### PR TITLE
fix: cannot find module 'tslint'

### DIFF
--- a/lib/provider/tslintjson.ts
+++ b/lib/provider/tslintjson.ts
@@ -91,7 +91,11 @@ async function getRules(fileName: string, opts: Options): Promise<Map<string, Pa
         console.log(`read ${configFileName} for ${fileName}`);
     }
 
-    const { Configuration } = await import("tslint");
-    const { rules } = Configuration.loadConfigurationFromPath(configFileName);
-    return rules;
+    try {
+        const { Configuration } = await import("tslint");
+        const { rules } = Configuration.loadConfigurationFromPath(configFileName);
+        return rules;
+    } catch {
+        return undefined;
+    }
 }


### PR DESCRIPTION
In case tslint is not installed one would get the following error `Cannot find module 'tslint'`

This is due `tslint` is not a direct dependency of `typescript-formatter`