### PR TITLE
Add support for globing arguments on Windows

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -9,7 +9,7 @@ import * as ts from "typescript";
 import * as fs from "fs";
 import * as path from "path";
 import * as commandpost from "commandpost";
-import * as globArgs from "glob-args";
+import * as glob from "glob";
 import * as lib from "./";
 import { getConfigFileName, readFilesFromTsconfig } from "./utils";
 
@@ -94,7 +94,14 @@ let root = commandpost
             process.stdout.write(root.helpText() + "\n");
             return;
         }
-        files = globArgs(files);
+        let matchedFiles = new Array();
+        files.forEach((pattern) => {
+            const matched = glob.sync(pattern);
+            if (matched) {
+                matchedFiles.concat(matched);
+            }
+        });
+        files = matchedFiles;
 
         if (verbose) {
             const printPool: { [name: string]: string; } = {};

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -9,7 +9,7 @@ import * as ts from "typescript";
 import * as fs from "fs";
 import * as path from "path";
 import * as commandpost from "commandpost";
-
+import * as globArgs from "glob-args";
 import * as lib from "./";
 import { getConfigFileName, readFilesFromTsconfig } from "./utils";
 
@@ -94,6 +94,7 @@ let root = commandpost
             process.stdout.write(root.helpText() + "\n");
             return;
         }
+        files = globArgs(files);
 
         if (verbose) {
             const printPool: { [name: string]: string; } = {};

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -97,8 +97,8 @@ let root = commandpost
         let matchedFiles = new Array();
         files.forEach((pattern) => {
             const matched = glob.sync(pattern);
-            if (matched) {
-                matchedFiles.concat(matched);
+            if (matched && matched.length > 0) {
+                matchedFiles = matchedFiles.concat(matched);
             }
         });
         files = matchedFiles;

--- a/package.json
+++ b/package.json
@@ -34,12 +34,13 @@
   "dependencies": {
     "commandpost": "^1.0.0",
     "editorconfig": "^0.15.0",
-    "glob-args": "^0.2.1"
+    "glob": "^7.1.2"
   },
   "peerDependencies": {
     "typescript": "^2.1.6 || ^3.0.0 || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev"
   },
   "devDependencies": {
+    "@types/glob": "^5.0.35",
     "@types/mkdirp": "^0.5.0",
     "@types/mocha": "^5.0.0",
     "@types/node": "^10.3.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   },
   "dependencies": {
     "commandpost": "^1.0.0",
-    "editorconfig": "^0.15.0"
+    "editorconfig": "^0.15.0",
+    "glob-args": "^0.2.1"
   },
   "peerDependencies": {
     "typescript": "^2.1.6 || ^3.0.0 || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev"


### PR DESCRIPTION
This makes calls like `tsfmt src/*.ts` work on Windows.