### PR TITLE
fix(provider): read TS Lint indent size

### DIFF
--- a/lib/provider/tslintjson.ts
+++ b/lib/provider/tslintjson.ts
@@ -22,7 +22,8 @@ export async function makeFormatCodeOptions(fileName: string, opts: Options, for
     const whitespace = rules.get("whitespace");
 
     if (indent && indent.ruleArguments) {
-        switch (indent.ruleArguments[0]) {
+        const [character, size] = indent.ruleArguments;
+        switch (character) {
             case "spaces":
                 formatSettings.convertTabsToSpaces = true;
                 break;
@@ -31,6 +32,9 @@ export async function makeFormatCodeOptions(fileName: string, opts: Options, for
                 break;
             default:
                 break;
+        }
+        if (typeof size === 'number') {
+            formatSettings.indentSize = size;
         }
     }
     if (whitespace && whitespace.ruleArguments) {


### PR DESCRIPTION
The TS Lint [`indent` rule](https://palantir.github.io/tslint/rules/indent/) can specify the indentation size:

```
"indent": [true, "spaces"]
```
```
"indent": [true, "spaces", 4]
```
```
"indent": [true, "tabs", 2]
```

This patch allows `tsfmt` to read that size and correctly set the formatting options. This means that `tslint` and `tsfmt` do not fight over the indentation size.