### PR TITLE
Change colorization of comment in json code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ insert_final_newline = true
 
 5th. Read settings from .vscode/settings.json ([VisualStudio Code](https://code.visualstudio.com/Docs/customization/userandworkspace))
 
-```json
+```jsonc
 {
   // Place your settings in this file to overwrite default and user settings.
   "typescript.format.enable": true,


### PR DESCRIPTION
GitHub colors comments in a json block strangely, so use `jsonc` instead.

Makes this:
![image](https://user-images.githubusercontent.com/2544493/82004175-3fba6c00-9630-11ea-9966-d9c6c233ce95.png)

look like this:
![image](https://user-images.githubusercontent.com/2544493/82004196-4ba62e00-9630-11ea-9c7b-95df4133c5e1.png)
