### PR TITLE
Support typescript@4 peerDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "editorconfig": "^0.15.0"
   },
   "peerDependencies": {
-    "typescript": "^2.1.6 || ^3.0.0 || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev"
+    "typescript": "^2.1.6 || ^3.0.0 || ^4.0.0 || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev"
   },
   "devDependencies": {
     "@types/mkdirp": "^0.5.0",


### PR DESCRIPTION
Given that:

1. TS generally doesn't respect semantic versioning
2. Looking at https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#breaking-changes ,
I don't see breaking changes that would impact typescript-formatter
3. My own usage of typescript-formatter (through https://github.com/lukeautry/tsoa )
is happy about 4.0.

, it seems reasonable to support TS 4.x.