### PR TITLE
Update readme json code block to jsonc

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ insert_final_newline = true
 
 5th. Read settings from .vscode/settings.json ([VisualStudio Code](https://code.visualstudio.com/Docs/customization/userandworkspace))
 
-```json
+```jsonc
 {
   // Place your settings in this file to overwrite default and user settings.
   "typescript.format.enable": true,


### PR DESCRIPTION
GitHub doesn't apply proper syntax highlight for comments in json code blocks. By changing the code block type to `jsonc` the comment will actually be highlighted as comments.

Turns this:
![image](https://user-images.githubusercontent.com/2544493/96152476-962b1f80-0eda-11eb-9e43-0d684537b09f.png)

into this:
![image](https://user-images.githubusercontent.com/2544493/96152501-9d522d80-0eda-11eb-9cce-2d4f6e8e5de5.png)
